### PR TITLE
Feat/Implementação do Bônus — Segurança com Spring Security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,16 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.5.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
@@ -56,12 +66,12 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-mysql</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,18 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/br/com/alura/AluraFake/authentication/AuthenticationController.java
+++ b/src/main/java/br/com/alura/AluraFake/authentication/AuthenticationController.java
@@ -1,0 +1,42 @@
+package br.com.alura.AluraFake.authentication;
+
+import br.com.alura.AluraFake.exception.EmailAlreadyRegisteredException;
+import br.com.alura.AluraFake.exception.EmailOrPasswordInvalidException;
+import br.com.alura.AluraFake.user.dto.UserAuthenticationDTO;
+import br.com.alura.AluraFake.user.dto.UserLoginResponseDTO;
+import br.com.alura.AluraFake.user.dto.UserRegisterDTO;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("auth")
+public class AuthenticationController {
+
+    private final AuthenticationService authenticationService;
+
+    public AuthenticationController(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<UserLoginResponseDTO> login(@RequestBody @Valid UserAuthenticationDTO userAuthenticationDTO) throws EmailOrPasswordInvalidException {
+        Optional<UserLoginResponseDTO> userLoginResponseDTO = authenticationService.login(userAuthenticationDTO);
+        if (userLoginResponseDTO.isPresent()) {
+            return ResponseEntity.ok().build();
+        }
+
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new UserLoginResponseDTO("Invalid credentials"));
+    }
+
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void register(@RequestBody @Valid UserRegisterDTO userRegisterDTO) throws EmailAlreadyRegisteredException {
+        authenticationService.register(userRegisterDTO);
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/authentication/AuthenticationController.java
+++ b/src/main/java/br/com/alura/AluraFake/authentication/AuthenticationController.java
@@ -26,7 +26,7 @@ public class AuthenticationController {
     public ResponseEntity<UserLoginResponseDTO> login(@RequestBody @Valid UserAuthenticationDTO userAuthenticationDTO) throws EmailOrPasswordInvalidException {
         Optional<UserLoginResponseDTO> userLoginResponseDTO = authenticationService.login(userAuthenticationDTO);
         if (userLoginResponseDTO.isPresent()) {
-            return ResponseEntity.ok().build();
+            return ResponseEntity.ok().body(userLoginResponseDTO.get());
         }
 
         return ResponseEntity

--- a/src/main/java/br/com/alura/AluraFake/authentication/AuthenticationService.java
+++ b/src/main/java/br/com/alura/AluraFake/authentication/AuthenticationService.java
@@ -1,0 +1,65 @@
+package br.com.alura.AluraFake.authentication;
+
+import br.com.alura.AluraFake.exception.EmailAlreadyRegisteredException;
+import br.com.alura.AluraFake.exception.EmailOrPasswordInvalidException;
+import br.com.alura.AluraFake.infra.security.TokenService;
+import br.com.alura.AluraFake.user.UserRepository;
+import br.com.alura.AluraFake.user.dto.UserAuthenticationDTO;
+import br.com.alura.AluraFake.user.dto.UserLoginResponseDTO;
+import br.com.alura.AluraFake.user.dto.UserRegisterDTO;
+import br.com.alura.AluraFake.user.model.User;
+import jakarta.transaction.Transactional;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class AuthenticationService {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
+
+    public AuthenticationService(AuthenticationManager authenticationManager, UserRepository userRepository, TokenService tokenService) {
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.tokenService = tokenService;
+    }
+
+    public Optional<UserLoginResponseDTO> login(UserAuthenticationDTO userAuthenticationDTO) throws EmailOrPasswordInvalidException {
+        if (!userRepository.existsByEmail(userAuthenticationDTO.email())) {
+            throw new EmailOrPasswordInvalidException();
+        }
+
+        UsernamePasswordAuthenticationToken usernamePassword = new UsernamePasswordAuthenticationToken(
+                userAuthenticationDTO.email(),
+                userAuthenticationDTO.password()
+        );
+
+        Authentication authenticated = authenticationManager.authenticate(usernamePassword);
+        String token = tokenService.generateToken((User) authenticated.getPrincipal());
+
+        return Optional.of(new UserLoginResponseDTO(token));
+    }
+
+    @Transactional
+    public void register(UserRegisterDTO userRegisterDTO) throws EmailAlreadyRegisteredException {
+        if (userRepository.existsByEmail(userRegisterDTO.email())) {
+            throw new EmailAlreadyRegisteredException();
+        }
+
+        String encryptedPassword = new BCryptPasswordEncoder().encode(userRegisterDTO.password());
+        User user = new User(
+                userRegisterDTO.name(),
+                userRegisterDTO.email(),
+                userRegisterDTO.role(),
+                encryptedPassword
+        );
+
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/authentication/AuthorizationService.java
+++ b/src/main/java/br/com/alura/AluraFake/authentication/AuthorizationService.java
@@ -1,0 +1,26 @@
+package br.com.alura.AluraFake.authentication;
+
+import br.com.alura.AluraFake.user.UserRepository;
+import br.com.alura.AluraFake.user.model.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class AuthorizationService implements UserDetailsService {
+
+    final UserRepository repository;
+
+    public AuthorizationService(UserRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Optional<User> user = repository.findByEmail(email);
+        return user.orElse(null);
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/exception/EmailAlreadyRegisteredException.java
+++ b/src/main/java/br/com/alura/AluraFake/exception/EmailAlreadyRegisteredException.java
@@ -1,9 +1,13 @@
 package br.com.alura.AluraFake.exception;
 
-public class EmailAlreadyRegisteredException extends Throwable {
-    private String field = "email";
+public class EmailAlreadyRegisteredException extends Exception {
+    private static final String FIELD = "email";
 
     public EmailAlreadyRegisteredException() {
         super("Email já registrado");
+    }
+
+    public String getField() {
+        return FIELD;
     }
 }

--- a/src/main/java/br/com/alura/AluraFake/exception/EmailAlreadyRegisteredException.java
+++ b/src/main/java/br/com/alura/AluraFake/exception/EmailAlreadyRegisteredException.java
@@ -1,0 +1,9 @@
+package br.com.alura.AluraFake.exception;
+
+public class EmailAlreadyRegisteredException extends Throwable {
+    private String field = "email";
+
+    public EmailAlreadyRegisteredException() {
+        super("Email já registrado");
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/exception/EmailOrPasswordInvalidException.java
+++ b/src/main/java/br/com/alura/AluraFake/exception/EmailOrPasswordInvalidException.java
@@ -1,0 +1,13 @@
+package br.com.alura.AluraFake.exception;
+
+public class EmailOrPasswordInvalidException extends Exception {
+    private static final String FIELD = "email or password";
+
+    public EmailOrPasswordInvalidException() {
+        super("Email ou senha inválidos");
+    }
+
+    public String getField() {
+        return FIELD;
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/infra/security/SecurityConfiguration.java
+++ b/src/main/java/br/com/alura/AluraFake/infra/security/SecurityConfiguration.java
@@ -1,0 +1,50 @@
+package br.com.alura.AluraFake.infra.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    final SecurityFilter securityFilter;
+
+    public SecurityConfiguration(SecurityFilter securityFilter) {
+        this.securityFilter = securityFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/register").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/course/new", "/course/{id}/publish").hasRole("INSTRUCTOR")
+                        .anyRequest().authenticated())
+                .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/infra/security/SecurityFilter.java
+++ b/src/main/java/br/com/alura/AluraFake/infra/security/SecurityFilter.java
@@ -1,0 +1,59 @@
+package br.com.alura.AluraFake.infra.security;
+
+import br.com.alura.AluraFake.user.UserRepository;
+import br.com.alura.AluraFake.user.model.User;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+public class SecurityFilter extends OncePerRequestFilter {
+    final TokenService tokenService;
+    final UserRepository userRepository;
+
+    public SecurityFilter(TokenService tokenService, UserRepository userRepository) {
+        this.tokenService = tokenService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = recoverToken(request);
+        if (token != null) {
+            verifyTokenAndAuthenticate(token);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void verifyTokenAndAuthenticate(String token) {
+        String email = tokenService.validateToken(token);
+        Optional<User> user = userRepository.findByEmail(email);
+
+        if (user.isPresent()) {
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    user,
+                    null,
+                    user.get().getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+    }
+
+    private String recoverToken(HttpServletRequest request) {
+        var authorization = request.getHeader("Authorization");
+        if (authorization == null) return null;
+        return authorization.replace("Bearer ", "");
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/infra/security/TokenService.java
+++ b/src/main/java/br/com/alura/AluraFake/infra/security/TokenService.java
@@ -1,0 +1,39 @@
+package br.com.alura.AluraFake.infra.security;
+
+import br.com.alura.AluraFake.user.model.User;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Service
+public class TokenService {
+    @Value("${api.security.token.secret}")
+    private String secret;
+
+    public String generateToken(User user) {
+        Algorithm algorithm = Algorithm.HMAC256(secret);
+       return JWT.create()
+                .withIssuer("alura-fake")
+                .withSubject(user.getEmail())
+                .withExpiresAt(getExpirationTime())
+                .sign(algorithm);
+    }
+
+    public String validateToken(String token) {
+        Algorithm algorithm = Algorithm.HMAC256(secret);
+        return JWT.require(algorithm)
+                .withIssuer("alura-fake")
+                .build()
+                .verify(token)
+                .getSubject();
+    }
+
+    private Instant getExpirationTime() {
+        return LocalDateTime.now().plusHours(1).toInstant(ZoneOffset.of("-03:00"));
+    }
+}

--- a/src/main/java/br/com/alura/AluraFake/user/dto/UserAuthenticationDTO.java
+++ b/src/main/java/br/com/alura/AluraFake/user/dto/UserAuthenticationDTO.java
@@ -1,0 +1,4 @@
+package br.com.alura.AluraFake.user.dto;
+
+public record UserAuthenticationDTO(String email, String password) {
+}

--- a/src/main/java/br/com/alura/AluraFake/user/dto/UserLoginResponseDTO.java
+++ b/src/main/java/br/com/alura/AluraFake/user/dto/UserLoginResponseDTO.java
@@ -1,0 +1,4 @@
+package br.com.alura.AluraFake.user.dto;
+
+public record UserLoginResponseDTO(String token) {
+}

--- a/src/main/java/br/com/alura/AluraFake/user/dto/UserRegisterDTO.java
+++ b/src/main/java/br/com/alura/AluraFake/user/dto/UserRegisterDTO.java
@@ -1,0 +1,19 @@
+package br.com.alura.AluraFake.user.dto;
+
+import br.com.alura.AluraFake.user.model.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserRegisterDTO(
+        @NotBlank
+        String name,
+        @NotBlank
+        @Email
+        String email,
+        @NotNull
+        Role role,
+        @NotNull
+        String password
+) {
+}

--- a/src/main/java/br/com/alura/AluraFake/user/model/User.java
+++ b/src/main/java/br/com/alura/AluraFake/user/model/User.java
@@ -2,11 +2,16 @@ package br.com.alura.AluraFake.user.model;
 
 import br.com.alura.AluraFake.util.PasswordGeneration;
 import jakarta.persistence.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 
 @Entity
-public class User {
+public class User implements UserDetails{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,7 +58,37 @@ public class User {
         return Role.INSTRUCTOR.equals(this.role);
     }
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + this.role.name()));
+    }
+
     public String getPassword() {
         return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 }

--- a/src/main/java/br/com/alura/AluraFake/util/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/alura/AluraFake/util/GlobalExceptionHandler.java
@@ -1,7 +1,11 @@
 package br.com.alura.AluraFake.util;
 
 import br.com.alura.AluraFake.exception.DomainException;
+import br.com.alura.AluraFake.exception.EmailAlreadyRegisteredException;
+import br.com.alura.AluraFake.exception.EmailOrPasswordInvalidException;
 import br.com.alura.AluraFake.exception.ForbiddenException;
+import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -33,5 +37,26 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorItemDTO> handleForbiddenException(ForbiddenException ex) {
         ErrorItemDTO error = new ErrorItemDTO(ex.getField(), ex.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+    }
+
+    @ExceptionHandler({JWTCreationException.class, JWTVerificationException.class})
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<ErrorItemDTO> handleJWTCreationException(RuntimeException ex) {
+        ErrorItemDTO error = new ErrorItemDTO("token", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+    }
+
+    @ExceptionHandler(EmailAlreadyRegisteredException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ResponseEntity<ErrorItemDTO> handleEmailAlreadyRegisteredException(EmailAlreadyRegisteredException ex) {
+        ErrorItemDTO error = new ErrorItemDTO(ex.getField(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    @ExceptionHandler(EmailOrPasswordInvalidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorItemDTO> handleEmailAlreadyRegisteredException(EmailOrPasswordInvalidException ex) {
+        ErrorItemDTO error = new ErrorItemDTO(ex.getField(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 }

--- a/src/main/resources/db/migration/V5__alterTableUser.sql
+++ b/src/main/resources/db/migration/V5__alterTableUser.sql
@@ -1,0 +1,2 @@
+ALTER TABLE User
+    MODIFY password VARCHAR(255) NOT NULL;

--- a/src/test/java/br/com/alura/AluraFake/course/CourseControllerTest.java
+++ b/src/test/java/br/com/alura/AluraFake/course/CourseControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.alura.AluraFake.course;
 
+import br.com.alura.AluraFake.AluraFakeApplication;
 import br.com.alura.AluraFake.course.dto.CourseListItemDTO;
 import br.com.alura.AluraFake.course.dto.NewCourseDTO;
 import br.com.alura.AluraFake.course.model.CourseStatus;
@@ -7,12 +8,19 @@ import br.com.alura.AluraFake.exception.domain.CourseIsNotBuildingException;
 import br.com.alura.AluraFake.exception.domain.CourseNotFoundException;
 import br.com.alura.AluraFake.exception.domain.MissingRequiredTaskTypesException;
 import br.com.alura.AluraFake.exception.forbidden.NotAnInstructorException;
+import br.com.alura.AluraFake.infra.security.SecurityConfiguration;
+import br.com.alura.AluraFake.infra.security.TokenService;
+import br.com.alura.AluraFake.user.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
@@ -24,6 +32,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ExtendWith(value = SpringExtension.class)
+@ContextConfiguration(classes = {
+        AluraFakeApplication.class,
+        SecurityConfiguration.class}
+)
 @WebMvcTest(CourseController.class)
 class CourseControllerTest {
 
@@ -33,9 +46,16 @@ class CourseControllerTest {
     @MockBean
     private CourseService courseService;
 
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    private UserRepository userRepository;
+
     @Autowired
     private ObjectMapper objectMapper;
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void createCourse_should_return_bad_request_when_dto_is_invalid() throws Exception {
         NewCourseDTO invalidCourse = new NewCourseDTO("Java", "Java", "invalid-email");
@@ -48,6 +68,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$[0].message").isNotEmpty());
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void createCourse_should_return_forbidden_when_instructor_not_found() throws Exception {
         NewCourseDTO newCourse = new NewCourseDTO("Java", "Java", "paulo@alura.com.br");
@@ -63,6 +84,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void createCourse_should_return_created_when_valid() throws Exception {
         NewCourseDTO newCourse = new NewCourseDTO("Java", "Java", "paulo@alura.com.br");
@@ -75,6 +97,7 @@ class CourseControllerTest {
         verify(courseService, times(1)).createCourse(any(NewCourseDTO.class));
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void listAllCourses_should_return_course_list() throws Exception {
         CourseListItemDTO expectedFirstCourse = new CourseListItemDTO(1L, "Java", "Curso de Java", CourseStatus.BUILDING);
@@ -95,6 +118,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$[1].status").value(expectedLastCourse.status().toString()));
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void publishCourse_should_return_unprocessable_entity_when_course_not_found() throws Exception {
         Long courseId = 1L;
@@ -107,6 +131,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void publishCourse_should_return_unprocessable_entity_when_missing_tasks_with_other_types() throws Exception {
         Long courseId = 1L;
@@ -119,6 +144,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void publishCourse_should_return_unprocessable_entity_when_not_building() throws Exception {
         Long courseId = 1L;
@@ -131,6 +157,7 @@ class CourseControllerTest {
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void publishCourse_should_return_ok_when_valid() throws Exception {
         Long courseId = 1L;

--- a/src/test/java/br/com/alura/AluraFake/task/TaskControllerTest.java
+++ b/src/test/java/br/com/alura/AluraFake/task/TaskControllerTest.java
@@ -1,17 +1,25 @@
 package br.com.alura.AluraFake.task;
 
+import br.com.alura.AluraFake.AluraFakeApplication;
 import br.com.alura.AluraFake.alternative.dto.NewAlternativeDTO;
 import br.com.alura.AluraFake.exception.domain.*;
+import br.com.alura.AluraFake.infra.security.SecurityConfiguration;
+import br.com.alura.AluraFake.infra.security.TokenService;
 import br.com.alura.AluraFake.task.dto.NewMultipleChoiceTaskDTO;
 import br.com.alura.AluraFake.task.dto.NewOpenTextTaskDTO;
 import br.com.alura.AluraFake.task.dto.NewSingleChoiceTaskDTO;
 import br.com.alura.AluraFake.task.dto.TaskListItemDTO;
+import br.com.alura.AluraFake.user.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
@@ -23,6 +31,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ExtendWith(value = SpringExtension.class)
+@ContextConfiguration(classes = {
+        AluraFakeApplication.class,
+        SecurityConfiguration.class}
+)
 @WebMvcTest(TaskController.class)
 class TaskControllerTest {
 
@@ -31,6 +44,12 @@ class TaskControllerTest {
 
     @MockBean
     private TaskService taskService;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    private UserRepository userRepository;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -72,7 +91,7 @@ class TaskControllerTest {
 
         return newMultipleChoiceTaskDTO;
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void createOpenTextTask_should_return_unprocessable_entity_when_course_not_found() throws Exception {
         NewOpenTextTaskDTO newOpenTextTaskDTO = getValidNewOpenTextTaskDTO();
@@ -86,7 +105,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.field").value("courseId"))
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newOpenTextExercise__should_return_unprocessable_entity_when_statement_is_duplicated_by_course_id() throws Exception {
         NewOpenTextTaskDTO newOpenTextTaskDTO = getValidNewOpenTextTaskDTO();
@@ -107,7 +126,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newOpenTextExercise__should_return_unprocessable_entity_when_course_is_not_building() throws Exception {
         NewOpenTextTaskDTO newOpenTextTaskDTO = getValidNewOpenTextTaskDTO();
@@ -124,7 +143,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newOpenTextExercise__should_return_unprocessable_entity_when_order_is_out_of_sequence() throws Exception {
         NewOpenTextTaskDTO newOpenTextTaskDTO = getValidNewOpenTextTaskDTO();
@@ -142,7 +161,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newOpenTextExercise_should_return_created_when_valid() throws Exception {
         NewOpenTextTaskDTO newOpenTextTaskDTO = getValidNewOpenTextTaskDTO();
@@ -154,7 +173,7 @@ class TaskControllerTest {
                         .content(objectMapper.writeValueAsString(newOpenTextTaskDTO)))
                 .andExpect(status().isCreated());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newSingleChoice_should_return_unprocessable_entity_when_course_not_found() throws Exception {
         NewSingleChoiceTaskDTO newSingleChoiceTaskDTO = getValidNewSingleChoiceTaskDTO();
@@ -169,7 +188,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.field").value("courseId"))
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newSingleChoice__should_return_unprocessable_entity_when_statement_is_duplicated_by_course_id() throws Exception {
         NewSingleChoiceTaskDTO invalidTask = getValidNewSingleChoiceTaskDTO();
@@ -190,7 +209,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newSingleChoice__should_return_unprocessable_entity_when_course_is_not_building() throws Exception {
         NewSingleChoiceTaskDTO taskNotInBuilding = getValidNewSingleChoiceTaskDTO();
@@ -207,7 +226,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newSingleChoice__should_return_unprocessable_entity_when_order_is_out_of_sequence() throws Exception {
         NewSingleChoiceTaskDTO newSingleChoiceTaskDTO = getValidNewSingleChoiceTaskDTO();
@@ -224,7 +243,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newSingleChoice_should_return_unprocessable_entity_when_options_invalid() throws Exception {
         NewSingleChoiceTaskDTO newSingleChoiceTaskDTO = getValidNewSingleChoiceTaskDTO();
@@ -241,7 +260,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.field").value("options"))
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newSingleChoice_should_return_unprocessable_entity_when_duplicate_options() throws Exception {
         NewSingleChoiceTaskDTO newSingleChoiceTaskDTO = getValidNewSingleChoiceTaskDTO();
@@ -256,7 +275,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.field").value("options"))
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newSingleChoice_should_return_created_when_valid() throws Exception {
         NewSingleChoiceTaskDTO newSingleChoiceTaskDTO = getValidNewSingleChoiceTaskDTO();
@@ -268,7 +287,7 @@ class TaskControllerTest {
 
         verify(taskService, times(1)).newSingleChoice(any(NewSingleChoiceTaskDTO.class));
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newMultipleChoice_should_return_unprocessable_entity_when_course_not_found() throws Exception {
         NewMultipleChoiceTaskDTO newMultipleChoiceTaskDTO = getValidNewMultipleChoiceTaskDTO();
@@ -283,7 +302,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.field").value("courseId"))
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newMultipleChoice__should_return_unprocessable_entity_when_statement_is_duplicated_by_course_id() throws Exception {
         NewMultipleChoiceTaskDTO invalidTask = getValidNewMultipleChoiceTaskDTO();
@@ -304,7 +323,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newMultipleChoice__should_return_unprocessable_entity_when_course_is_not_building() throws Exception {
         NewMultipleChoiceTaskDTO taskNotInBuilding = getValidNewMultipleChoiceTaskDTO();
@@ -321,7 +340,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newMultipleChoice__should_return_unprocessable_entity_when_order_is_out_of_sequence() throws Exception {
         NewMultipleChoiceTaskDTO newMultipleChoiceTaskDTO = getValidNewMultipleChoiceTaskDTO();
@@ -337,7 +356,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.message")
                         .isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newMultipleChoice__should_return_unprocessable_entity_when_options_invalid() throws Exception {
         NewMultipleChoiceTaskDTO taskDTO = getValidNewMultipleChoiceTaskDTO();
@@ -354,7 +373,7 @@ class TaskControllerTest {
                 .andExpect(jsonPath("$.field").value("options"))
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newMultipleChoice_should_return_created_when_valid() throws Exception {
         NewMultipleChoiceTaskDTO taskDTO = getValidNewMultipleChoiceTaskDTO();
@@ -366,7 +385,7 @@ class TaskControllerTest {
 
         verify(taskService, times(1)).newMultipleChoice(any(NewMultipleChoiceTaskDTO.class));
     }
-
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void listAllTasks_should_return_task_list() throws Exception {
         TaskListItemDTO yagniTask = new TaskListItemDTO(1L, "Explique o que é YAGNI e as vantagens da sua utilização.", 1);

--- a/src/test/java/br/com/alura/AluraFake/user/UserControllerTest.java
+++ b/src/test/java/br/com/alura/AluraFake/user/UserControllerTest.java
@@ -1,15 +1,22 @@
 package br.com.alura.AluraFake.user;
 
+import br.com.alura.AluraFake.AluraFakeApplication;
 import br.com.alura.AluraFake.exception.domain.DuplicateUserEmailException;
+import br.com.alura.AluraFake.infra.security.SecurityConfiguration;
+import br.com.alura.AluraFake.infra.security.TokenService;
 import br.com.alura.AluraFake.user.dto.NewUserDTO;
 import br.com.alura.AluraFake.user.dto.UserListItemDTO;
 import br.com.alura.AluraFake.user.model.Role;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -20,6 +27,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ExtendWith(value = SpringExtension.class)
+@ContextConfiguration(classes = {
+        AluraFakeApplication.class,
+        SecurityConfiguration.class}
+)
 @WebMvcTest(UserController.class)
 public class UserControllerTest {
 
@@ -29,9 +41,16 @@ public class UserControllerTest {
     @MockBean
     private UserService userService;
 
+    @MockBean
+    private TokenService tokenService;
+
+    @MockBean
+    private UserRepository userRepository;
+
     @Autowired
     private ObjectMapper objectMapper;
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newUser__should_return_bad_request_when_email_is_blank() throws Exception {
         NewUserDTO newUserDTO = new NewUserDTO("John Doe", "john.doe@example.com", Role.STUDENT, null);
@@ -44,6 +63,7 @@ public class UserControllerTest {
         verify(userService, times(1)).newStudent(newUserDTO);
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newUser__should_return_bad_request_when_email_is_invalid() throws Exception {
         NewUserDTO newUserDTO = new NewUserDTO("John Doe", "invalid-email", Role.STUDENT, null);
@@ -56,6 +76,7 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$[0].message").isNotEmpty());
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void newUser__should_return_unprocessable_entity_when_email_already_exists() throws Exception {
         NewUserDTO newUserDTO = new NewUserDTO("John Doe", "john.doe@example.com", Role.STUDENT, null);
@@ -69,6 +90,7 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
+    @WithMockUser(username = "instructor", roles = {"INSTRUCTOR"})
     @Test
     void listAllUsers__should_return_ok_and_list_users() throws Exception {
         UserListItemDTO user1 = new UserListItemDTO("John Doe", "john.doe@example.com", Role.STUDENT);


### PR DESCRIPTION
# Implementação de Segurança com Spring Security

## Qual é o propósito deste Pull Request?
- Implementar o **Bônus** da atividade: autenticação e autorização com Spring Security
- Restringir endpoints de criação de atividades e criação/publicação de cursos a usuários com role `INSTRUCTOR`
- Permitir acesso aos endpoints de listagem para qualquer usuário autenticado

## O que foi feito para atingir isso?
- Configuração do Spring Security para autenticação e autorização
- Alteração da tabela de user para armazenar senhas encriptadas (255 caracteres)
- Adição de novas exceptions:
  - `EmailOrPasswordInvalidException.java`
  - `EmailAlreadyRegisteredException.java`
- Implementação de autenticação e autorização baseada em roles
- Atualização dos testes das controllers para compatibilidade com segurança